### PR TITLE
Rust proto impl From -> Any for more generated messages

### DIFF
--- a/v4-proto-rs/src/lib.rs
+++ b/v4-proto-rs/src/lib.rs
@@ -3,15 +3,28 @@ pub use cosmos_sdk_proto;
 
 include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/_includes.rs"));
 
-use crate::dydxprotocol::clob::MsgPlaceOrder;
 use prost::Message;
+use prost_types;
 
-impl Into<prost_types::Any> for MsgPlaceOrder {
-    fn into(self) -> prost_types::Any {
-        let value = self.encode_to_vec();
-        prost_types::Any {
-            type_url: "/dydxprotocol.clob.MsgPlaceOrder".to_string(),
-            value,
+macro_rules! impl_prost_any_from {
+    ($type:ty) => {
+        impl From<$type> for prost_types::Any {
+            fn from(msg: $type) -> Self {
+                let value = msg.encode_to_vec();
+                let type_url = stringify!($type)
+                    .replace("crate::", "/")
+                    .replace("::", ".");
+                prost_types::Any {
+                    type_url,
+                    value,
+                }
+            }
         }
-    }
+    };
 }
+
+impl_prost_any_from!(crate::dydxprotocol::clob::MsgPlaceOrder);
+impl_prost_any_from!(crate::dydxprotocol::clob::MsgCancelOrder);
+impl_prost_any_from!(crate::dydxprotocol::sending::MsgCreateTransfer);
+impl_prost_any_from!(crate::dydxprotocol::sending::MsgDepositToSubaccount);
+impl_prost_any_from!(crate::dydxprotocol::sending::MsgWithdrawFromSubaccount);


### PR DESCRIPTION
- Changes `prost_types::Any` translation from `Into` to `From`;
- Adds related support for other messages.
