### PR TITLE
Impl Any::from MsgBatchCancel, MsgSend

### DIFF
--- a/v4-proto-rs/src/lib.rs
+++ b/v4-proto-rs/src/lib.rs
@@ -26,14 +26,41 @@ macro_rules! impl_prost_any_from {
 
 impl_prost_any_from!(crate::dydxprotocol::clob::MsgPlaceOrder);
 impl_prost_any_from!(crate::dydxprotocol::clob::MsgCancelOrder);
+impl_prost_any_from!(crate::dydxprotocol::clob::MsgBatchCancel);
 impl_prost_any_from!(crate::dydxprotocol::sending::MsgCreateTransfer);
 impl_prost_any_from!(crate::dydxprotocol::sending::MsgDepositToSubaccount);
 impl_prost_any_from!(crate::dydxprotocol::sending::MsgWithdrawFromSubaccount);
+
+macro_rules! impl_prost_any_from_wrapped {
+    ($type:ty, $wrapped:ident) => {
+        pub struct $wrapped(pub $type);
+        impl From<$wrapped> for prost_types::Any {
+            fn from(wmsg: $wrapped) -> Self {
+                let value = wmsg.0.encode_to_vec();
+                const TYPE: &str = stringify!($type);
+                const TYPE_WITH_ROOT: &str = replace!(TYPE, "crate::cosmos_sdk_proto::", "/");
+                const TYPE_AS_PATH: &str = replace!(TYPE_WITH_ROOT, "::", ".");
+                prost_types::Any {
+                    type_url: TYPE_AS_PATH.to_string(),
+                    value,
+                }
+            }
+        }
+    }
+}
+
+pub mod wrapped {
+    use const_str::replace;
+    use prost::Message;
+    impl_prost_any_from_wrapped!(crate::cosmos_sdk_proto::cosmos::bank::v1beta1::MsgSend, WrappedMsgSend);
+}
 
 #[cfg(test)]
 mod test {
     use crate::dydxprotocol::clob::MsgCancelOrder;
     use prost_types::Any;
+    use crate::cosmos_sdk_proto::cosmos::bank::v1beta1::MsgSend;
+    use crate::wrapped::WrappedMsgSend;
 
     #[test]
     pub fn test_any_conversion() {
@@ -43,6 +70,14 @@ mod test {
         };
         let any = Any::from(msg);
         let url = "/dydxprotocol.clob.MsgCancelOrder";
+        assert_eq!(any.type_url, url);
+    }
+
+    #[test]
+    pub fn test_any_conversion_wrapped() {
+        let msg = MsgSend::default();
+        let any = Any::from(WrappedMsgSend { 0: msg });
+        let url = "/cosmos.bank.v1beta1.MsgSend";
         assert_eq!(any.type_url, url);
     }
 }


### PR DESCRIPTION
Adds impl From for Any for `MsgBatchCancel`, `MsgSend`.
Also adds a new macro `impl_prost_any_from_wrapped!` for Cosmos external types. It would be to cool to just use one argument for this macro, inferring the Wrapped name type from the last word in the provided module path, though I didn't figure out how to provide a solution which would work at compile-time.