### PR TITLE
Add the `ToAny` trait

### DIFF
--- a/v4-proto-rs/Cargo.toml
+++ b/v4-proto-rs/Cargo.toml
@@ -13,7 +13,6 @@ cosmos-sdk-proto = "0.21.1"
 tonic = { version = "0.11", features = ["tls", "tls-roots", "transport", "channel"] }
 prost = "0.12"
 prost-types = "0.12"
-const-str = "0.5.7"
 
 [build-dependencies]
 tonic-buf-build = "0.2.1"

--- a/v4-proto-rs/examples/place_order.rs
+++ b/v4-proto-rs/examples/place_order.rs
@@ -27,6 +27,7 @@ use v4_proto_rs::dydxprotocol::clob::{
     MsgPlaceOrder, Order, OrderId,
 };
 use v4_proto_rs::dydxprotocol::subaccounts::SubaccountId;
+use v4_proto_rs::ToAny;
 
 const TIMEOUT_MILLIS: u64 = 1000;
 const ETH_USD_PAIR_ID: u32 = 1; // information on market id can be fetch from indexer API
@@ -155,7 +156,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let msg = prepare_order(subaccount, address)?;
 
     // Build and sign transaction
-    let tx_body = tx::BodyBuilder::new().msg(msg).memo("").finish();
+    let tx_body = tx::BodyBuilder::new().msg(msg.to_any()).memo("").finish();
     let amount = Coin {
         amount: 0u8.into(),
         denom: DYDX_FEE_DENOM.parse()?,

--- a/v4-proto-rs/src/lib.rs
+++ b/v4-proto-rs/src/lib.rs
@@ -3,64 +3,32 @@ pub use cosmos_sdk_proto;
 
 include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/_includes.rs"));
 
-use const_str::replace;
 use prost::Message;
 use prost_types;
+use std::any::type_name;
 
-macro_rules! impl_prost_any_from {
-    ($type:ty) => {
-        impl From<$type> for prost_types::Any {
-            fn from(msg: $type) -> Self {
-                let value = msg.encode_to_vec();
-                const TYPE: &str = stringify!($type);
-                const TYPE_WITH_ROOT: &str = replace!(TYPE, "crate::", "/");
-                const TYPE_AS_PATH: &str = replace!(TYPE_WITH_ROOT, "::", ".");
-                prost_types::Any {
-                    type_url: TYPE_AS_PATH.to_string(),
-                    value,
-                }
-            }
-        }
-    };
-}
-
-impl_prost_any_from!(crate::dydxprotocol::clob::MsgPlaceOrder);
-impl_prost_any_from!(crate::dydxprotocol::clob::MsgCancelOrder);
-impl_prost_any_from!(crate::dydxprotocol::clob::MsgBatchCancel);
-impl_prost_any_from!(crate::dydxprotocol::sending::MsgCreateTransfer);
-impl_prost_any_from!(crate::dydxprotocol::sending::MsgDepositToSubaccount);
-impl_prost_any_from!(crate::dydxprotocol::sending::MsgWithdrawFromSubaccount);
-
-macro_rules! impl_prost_any_from_wrapped {
-    ($type:ty, $wrapped:ident) => {
-        pub struct $wrapped(pub $type);
-        impl From<$wrapped> for prost_types::Any {
-            fn from(wmsg: $wrapped) -> Self {
-                let value = wmsg.0.encode_to_vec();
-                const TYPE: &str = stringify!($type);
-                const TYPE_WITH_ROOT: &str = replace!(TYPE, "crate::cosmos_sdk_proto::", "/");
-                const TYPE_AS_PATH: &str = replace!(TYPE_WITH_ROOT, "::", ".");
-                prost_types::Any {
-                    type_url: TYPE_AS_PATH.to_string(),
-                    value,
-                }
-            }
+pub trait ToAny: Message + Sized {
+    fn to_any(self) -> prost_types::Any {
+        let value = self.encode_to_vec();
+        let type_url = type_name::<Self>()
+            .replace("v4_proto_rs::", "/")
+            .replace("cosmos_sdk_proto::", "/")
+            .replace("::", ".")
+            .to_string();
+        prost_types::Any {
+            type_url,
+            value,
         }
     }
 }
 
-pub mod wrapped {
-    use const_str::replace;
-    use prost::Message;
-    impl_prost_any_from_wrapped!(crate::cosmos_sdk_proto::cosmos::bank::v1beta1::MsgSend, WrappedMsgSend);
-}
+impl<M: Message> ToAny for M {}
 
 #[cfg(test)]
 mod test {
+    use super::ToAny;
     use crate::dydxprotocol::clob::MsgCancelOrder;
-    use prost_types::Any;
     use crate::cosmos_sdk_proto::cosmos::bank::v1beta1::MsgSend;
-    use crate::wrapped::WrappedMsgSend;
 
     #[test]
     pub fn test_any_conversion() {
@@ -68,7 +36,7 @@ mod test {
             order_id: None,
             good_til_oneof: None,
         };
-        let any = Any::from(msg);
+        let any = msg.to_any();
         let url = "/dydxprotocol.clob.MsgCancelOrder";
         assert_eq!(any.type_url, url);
     }
@@ -76,7 +44,7 @@ mod test {
     #[test]
     pub fn test_any_conversion_wrapped() {
         let msg = MsgSend::default();
-        let any = Any::from(WrappedMsgSend { 0: msg });
+        let any = msg.to_any();
         let url = "/cosmos.bank.v1beta1.MsgSend";
         assert_eq!(any.type_url, url);
     }


### PR DESCRIPTION
The universal trait that let convert any `Message` instance to the `Any` type.
We've lost the constant string efficiency, but don't have to add more types manually.
If one day the `type_name()` function become `const` we could improve that.